### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,9 +2,9 @@ LEDstrip	KEYWORD1
 SetRGBColour	KEYWORD2
 SetRandomColour	KEYWORD2
 SetWhiteLight	KEYWORD2
-DefineRGBLED KEYWORD2
-DefineSingleColourLED KEYWORD2
-SetAdvRandomColour KEYWORD2
+DefineRGBLED	KEYWORD2
+DefineSingleColourLED	KEYWORD2
+SetAdvRandomColour	KEYWORD2
 SetRedLight	KEYWORD2
 SetGreenLight	KEYWORD2
 SetBlueLight	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords